### PR TITLE
Install ca-certificates to support LetsEncrypt

### DIFF
--- a/manifest/sftp/Dockerfile
+++ b/manifest/sftp/Dockerfile
@@ -5,9 +5,10 @@ ARG VERSION
 ENV SFTP_VERSION=${VERSION} \
     UID=500
 
-RUN mkdir /srv/daemon -p; \
-    wget -P /srv/daemon https://github.com/pterodactyl/sftp-server/releases/download/${SFTP_VERSION}/sftp-server; \
-    chmod +x /srv/daemon/sftp-server; \
+RUN apk add --no-cache ca-certificates && \
+    mkdir /srv/daemon -p && \
+    wget -P /srv/daemon https://github.com/pterodactyl/sftp-server/releases/download/${SFTP_VERSION}/sftp-server && \
+    chmod +x /srv/daemon/sftp-server && \
     addgroup -S -g ${UID} pterodactyl && adduser -S -D -H -G pterodactyl -u ${UID} -s /bin/false pterodactyl
 
 EXPOSE 2022


### PR DESCRIPTION
Without ca-certificates your panel cannot be behind a LetsEncrypt certificate, sftp reaches out to the API on the panel, so without this it cannot validate your sftp credentials.

Further, the sftp server simply rejects your auth details and provides no details on why it failed.